### PR TITLE
Fixed a couple issue in the decryption and de-compression of audio fi…

### DIFF
--- a/Client/D2Client.cpp
+++ b/Client/D2Client.cpp
@@ -77,6 +77,22 @@ void D2Client_SetupServerConnection()
 }
 
 /*
+ *	Handle window events
+ */
+static void D2Client_HandleWindowEvent(WindowEvent windowEvent)
+{
+	switch (windowEvent.event)
+	{
+		case D2WindowEventType::WINDOWEVENT_FOCUS_GAINED:
+			engine->S_ResumeAudio();
+			break;
+		case D2WindowEventType::WINDOWEVENT_FOCUS_LOST:
+			engine->S_PauseAudio();
+			break;
+	}
+}
+
+/*
  *	Pump input
  */
 static void D2Client_HandleInput()
@@ -87,10 +103,12 @@ static void D2Client_HandleInput()
 	for (DWORD i = 0; i < openConfig->dwNumPendingCommands; i++)
 	{
 		D2CommandQueue* pCmd = &openConfig->pCmds[i];
-		
-		// Handle all of the different event types
+				// Handle all of the different event types
 		switch (pCmd->cmdType)
 		{
+			case IN_WINDOW:
+				D2Client_HandleWindowEvent(pCmd->cmdData.window);
+				break;
 			case IN_MOUSEMOVE:
 				cl.dwMouseX = pCmd->cmdData.motion.x;
 				cl.dwMouseY = pCmd->cmdData.motion.y;

--- a/Game/Audio.cpp
+++ b/Game/Audio.cpp
@@ -35,24 +35,39 @@ namespace Audio
 		return Audio_SDL::PlaySound(handle, loops);
 	}
 
+	void PlayMusic(mus_handle music, int loops)
+	{
+		return Audio_SDL::PlayMusic(music, loops);
+	}
+
+	void PauseAudio()
+	{
+		return Audio_SDL::PauseAudio();
+	}
+
+	void ResumeAudio()
+	{
+		return Audio_SDL::ResumeAudio();
+	}
+
 	// Change master volume
-	void SetMasterVolume(float fNewVolume)
+	void SetMasterVolume(float volume)
 	{
 		// Just pipe it into SDL for now
-		Audio_SDL::SetMasterVolume(fNewVolume);
+		Audio_SDL::SetMasterVolume(volume);
 	}
 
 	// Change music volume
-	void SetMusicVolume(float fNewVolume)
+	void SetMusicVolume(float volume)
 	{
 		// Just pipe it into SDL for now
-		Audio_SDL::SetMusicVolume(fNewVolume);
+		Audio_SDL::SetMusicVolume(volume);
 	}
 
 	// Change sound volume
-	void SetSoundVolume(float fNewVolume)
+	void SetSoundVolume(float volume)
 	{
 		// Just pipe it into SDL for now
-		Audio_SDL::SetSoundVolume(fNewVolume);
+		Audio_SDL::SetSoundVolume(volume);
 	}
 }

--- a/Game/Audio_SDL.cpp
+++ b/Game/Audio_SDL.cpp
@@ -202,33 +202,65 @@ namespace Audio_SDL
 	}
 
 	// Play a sound
-	void PlaySound(sfx_handle sound, int loops)
+	void PlaySound(sfx_handle handle, int loops)
 	{
-		if (sound == INVALID_HANDLE || sound >= MAX_SDL_SOUNDFILES)
+		if (handle == INVALID_HANDLE || handle >= MAX_SDL_SOUNDFILES)
 		{
 			return;
 		}
 
-		if (!gpSoundCache[sound].pChunk)
+		if (!gpSoundCache[handle].pChunk)
 		{
 			return;
 		}
 
-		Mix_PlayChannel(-1, gpSoundCache[sound].pChunk, 0);
+		Mix_PlayChannel(-1, gpSoundCache[handle].pChunk, 0);
+	}
+
+	// Play music
+	void PlayMusic(mus_handle handle, int loops)
+	{
+		if (handle == INVALID_HANDLE || handle >= MAX_SDL_SOUNDFILES)
+		{
+			return;
+		}
+
+		if (!gpSoundCache[handle].pChunk)
+		{
+			return;
+		}
+
+		Mix_PlayMusic(gpSoundCache[handle].pMusic, loops);
+	}
+
+	void PauseAudio()
+	{
+		Mix_Pause(-1);
+		Mix_PauseMusic();
+	}
+
+	void ResumeAudio()
+	{
+		Mix_Resume(-1);
+		Mix_ResumeMusic();
 	}
 
 	// Change the master volume
-	void SetMasterVolume(float fNewVolume)
+	void SetMasterVolume(float volume)
 	{
+		SetMusicVolume(volume);
+		SetSoundVolume(volume);
 	}
 
 	// Change the music volume
-	void SetMusicVolume(float fNewVolume)
+	void SetMusicVolume(float volume)
 	{
+		Mix_VolumeMusic(volume);
 	}
 
 	// Change the sound volume
-	void SetSoundVolume(float fNewVolume)
+	void SetSoundVolume(float volume)
 	{
+		Mix_Volume(-1, volume);
 	}
 }

--- a/Game/Audio_SDL.hpp
+++ b/Game/Audio_SDL.hpp
@@ -14,10 +14,13 @@ namespace Audio_SDL
 	void FlushAudioData();
 
 	void PlaySound(sfx_handle handle, int loops);
+	void PlayMusic(mus_handle handle, int loops);
+	void PauseAudio();
+	void ResumeAudio();
 
-	void SetMasterVolume(float fNewVolume);
-	void SetMusicVolume(float fNewVolume);
-	void SetSoundVolume(float fNewVolume);
+	void SetMasterVolume(float volume);
+	void SetMusicVolume(float volume);
+	void SetSoundVolume(float volume);
 
 	struct SoundCacheEntry
 	{

--- a/Game/Diablo2.hpp
+++ b/Game/Diablo2.hpp
@@ -701,9 +701,12 @@ namespace Audio
 	sfx_handle RegisterSound(char* szAudioFile);
 	mus_handle RegisterMusic(char* szAudioFile);
 	void PlaySound(sfx_handle handle, int loops);
-	void SetMasterVolume(float fNewVolume);
-	void SetMusicVolume(float fNewVolume);
-	void SetSoundVolume(float fNewVolume);
+	void PlayMusic(mus_handle handle, int loops);
+	void PauseAudio();
+	void ResumeAudio();
+	void SetMasterVolume(float volume);
+	void SetMusicVolume(float volume);
+	void SetSoundVolume(float volume);
 }
 
 // COF.cpp

--- a/Game/FileSystem.cpp
+++ b/Game/FileSystem.cpp
@@ -486,7 +486,7 @@ namespace FS
 		for (int i = FS_MAXPATH - 1; i >= 0; i--)	// go in reverse since we're reading
 		{
 			D2Lib::strncpyz(szBuffer, pszPaths[i], dwBufferLen);
-			strcat(szBuffer, szFileName);
+			strncat(szBuffer, szFileName, strlen(szFileName));
 			f = fopen(szBuffer, "r");
 			if (f != nullptr)
 			{	// at this point, szBuffer will point to the correct file path

--- a/Game/Input.cpp
+++ b/Game/Input.cpp
@@ -72,6 +72,11 @@ namespace IN
 		{
 			switch (ev.type)
 			{
+			case SDL_WINDOWEVENT:
+				gProcessedCommands[gdwNumProcessedCommands].cmdType = IN_WINDOW;
+				gProcessedCommands[gdwNumProcessedCommands].cmdData.window.event = (D2WindowEventType)ev.window.event;
+				gdwNumProcessedCommands++;
+				break;
 			case SDL_MOUSEMOTION:
 				//				if (D2Win_InFocus(ev.motion.windowID))
 			{

--- a/Game/diablo2.cpp
+++ b/Game/diablo2.cpp
@@ -144,6 +144,12 @@ static D2ModuleImportStrc exports = {
 	Audio::RegisterSound,
 	Audio::RegisterMusic,
 	Audio::PlaySound,
+	Audio::PlayMusic,
+	Audio::PauseAudio,
+	Audio::ResumeAudio,
+	Audio::SetMasterVolume,
+	Audio::SetMusicVolume,
+	Audio::SetSoundVolume
 };
 
 static D2ModuleExportStrc* imports[MODULE_MAX]{ 0 };

--- a/Shared/D2Shared.hpp
+++ b/Shared/D2Shared.hpp
@@ -208,6 +208,28 @@ enum D2InputCommand
 	IN_TEXTINPUT,
 	IN_TEXTEDITING,
 	IN_QUIT,
+	IN_WINDOW
+};
+
+enum D2WindowEventType
+{
+	WINDOWEVENT_NONE,           /**< Never used */
+	WINDOWEVENT_SHOWN,          /**< Window has been shown */
+	WINDOWEVENT_HIDDEN,         /**< Window has been hidden */
+	WINDOWEVENT_EXPOSED,        /**< Window has been exposed and should be redrawn */
+	WINDOWEVENT_MOVED,          /**< Window has been moved to data1, data2 */
+	WINDOWEVENT_RESIZED,        /**< Window has been resized to data1xdata2 */
+	WINDOWEVENT_SIZE_CHANGED,   /**< The window size has changed, either as a result of an API call or through the system or user changing the window size. */
+	WINDOWEVENT_MINIMIZED,      /**< Window has been minimized */
+	WINDOWEVENT_MAXIMIZED,      /**< Window has been maximized */
+	WINDOWEVENT_RESTORED,       /**< Window has been restored to normal size and position */
+	WINDOWEVENT_ENTER,          /**< Window has gained mouse focus */
+	WINDOWEVENT_LEAVE,          /**< Window has lost mouse focus */
+	WINDOWEVENT_FOCUS_GAINED,   /**< Window has gained keyboard focus */
+	WINDOWEVENT_FOCUS_LOST,     /**< Window has lost keyboard focus */
+	WINDOWEVENT_CLOSE,          /**< The window manager requests that the window be closed */
+	WINDOWEVENT_TAKE_FOCUS,     /**< Window is being offered a focus (should SetWindowInputFocus() on itself or a subwindow, or ignore) */
+	WINDOWEVENT_HIT_TEST
 };
 
 // This is a direct mapping of the SDL scancodes, with a few extra things thrown in
@@ -500,6 +522,12 @@ struct D2GameConfigStrc     // size 0x3C7
 /*
  *	The command queue is iterated through on the client, and filled in by the engine when requested.
  */
+
+struct WindowEvent
+{
+	D2WindowEventType event;
+};
+
 struct D2CommandQueue
 {
 	D2InputCommand cmdType;
@@ -525,6 +553,7 @@ struct D2CommandQueue
 
 	union
 	{
+		WindowEvent			window;
 		MouseMotionEvent	motion;
 		ButtonEvent			button;
 		TextEvent			text;
@@ -646,6 +675,12 @@ struct D2ModuleImportStrc
 	sfx_handle		(*S_RegisterSound)(char* szAudioFile);
 	mus_handle		(*S_RegisterMusic)(char* szAudioFile);
 	void			(*S_PlaySound)(sfx_handle handle, int loops);
+	void			(*S_PlayMusic)(mus_handle handle, int loops);
+	void			(*S_PauseAudio)();
+	void			(*S_ResumeAudio)();
+	void			(*S_SetMasterVolume)(float volume);
+	void			(*S_SetMusicVolume)(float volume);
+	void			(*S_SetSoundVolume)(float volume);
 
 	// Renderer calls (should always be last)
 	tex_handle		(*R_RegisterDC6Texture)(char *szFileName, char* szHandleName, DWORD dwStart, DWORD dwEnd, int nPalette);


### PR DESCRIPTION
* Fixed a couple issue in the decryption and de-compression of audio files in D2 MPQ archives

-The encryption key was only valid for the first block of data. The encryption key for a specific block should be encryption key plus the index of the block (EncryptionKey + 1).
-The compression functions were designed to be called one after another, passing the output buffer from one to another. The issue was, it was not correctly passing the output buffer and the number of bytes written to the output buffer.


I tested this with the intro music that plays when you start D2 and it works perfectly
("data\\global\\music\\introedit.wav" in "d2xmusic.mpq").