### PR TITLE
Some linux build fixes.

### DIFF
--- a/Engine/FileSystem.cpp
+++ b/Engine/FileSystem.cpp
@@ -518,7 +518,7 @@ namespace FS
 		}
 
 		// Not allowed to Seek() on files from MPQs.
-		Log_WarnAssertReturn(!pRecord->bLoadedFromMPQ);
+		Log_WarnAssertVoidReturn(!pRecord->bLoadedFromMPQ);
 
 		SDL_LockMutex(pRecord->mut);
 		fseek(pRecord->handle, offset, nSeekType);

--- a/Engine/Platform_Linux.cpp
+++ b/Engine/Platform_Linux.cpp
@@ -1,4 +1,6 @@
 #include "Diablo2.hpp"
+#include "FileSystem.hpp"
+#include "Logging.hpp"
 #include <stdlib.h>
 #include <cstdio>
 #include <unistd.h>

--- a/Shared/D2Shared.cpp
+++ b/Shared/D2Shared.cpp
@@ -144,7 +144,7 @@ namespace D2Lib
 	char* fnext(char* szFileName)
 	{
 		char* szCurrent = szFileName;
-		while (szCurrent != '\0' && strchr(szCurrent + 1, '.') != nullptr)
+		while (*szCurrent != '\0' && strchr(szCurrent + 1, '.') != nullptr)
 		{
 			szCurrent++;
 		}


### PR DESCRIPTION
Hi,

I wanted to try this project, but there are several build issues on linux with `gcc9`. I think I was able to fix some of them, but please review.

1.
```
[1/71] Building CXX object CMakeFiles/D2Client.dir/Shared/D2Shared.cpp.o
samu: job failed: g++  -DD2CLIENT -DD2COMMON -DD2Client_EXPORTS  -fPIC   -std=gnu++11 -MD -MT CMakeFiles/D2Client.dir/Shared/D2Shared.cpp.o -MF CMakeFiles/D2Client.dir/Shared/D2Shared.cpp.o.d -o CMakeFiles/D2Client.dir/Shared/D2Shared.cpp.o -c ../Shared/D2Shared.cpp
In file included from ../Shared/D2Shared.cpp:1:
../Shared/D2Shared.hpp:738:80: warning: ‘visibility’ attribute ignored [-Wattributes]
  738 | typedef D2EXPORT D2ModuleExportStrc* (*GetAPIType)(D2ModuleImportStrc* pImports);
      |                                                                                ^
../Shared/D2Shared.cpp: In function ‘char* D2Lib::fnext(char*)’:
../Shared/D2Shared.cpp:147:23: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
  147 |   while (szCurrent != '
```
2.
```
[55/71] Building CXX object CMakeFiles/game.dir/Engine/Platform_Linux.cpp.o
samu: job failed: g++  -DD2EXE -I/usr/include/SDL2 -std=gnu++11 -MD -MT CMakeFiles/game.dir/Engine/Platform_Linux.cpp.o -MF CMakeFiles/game.dir/Engine/Platform_Linux.cpp.o.d -o CMakeFiles/game.dir/Engine/Platform_Linux.cpp.o -c ../Engine/Platform_Linux.cpp
In file included from ../Engine/Diablo2.hpp:2,
                 from ../Engine/Platform_Linux.cpp:1:
../Engine/../Shared/D2Shared.hpp:738:80: warning: ‘visibility’ attribute ignored [-Wattributes]
  738 | typedef D2EXPORT D2ModuleExportStrc* (*GetAPIType)(D2ModuleImportStrc* pImports);
      |                                                                                ^
../Engine/Platform_Linux.cpp: In function ‘char16_t* Sys::GetAdapterIP()’:
../Engine/Platform_Linux.cpp:88:10: warning: ISO C++ forbids converting a string constant to ‘char16_t*’ [-Wwrite-strings]
   88 |   return u"192.168.1.1";
      |          ^~~~~~~~~~~~~~
../Engine/Platform_Linux.cpp: In function ‘D2ModuleExportStrc* Sys::OpenModule(OpenD2Modules, D2ModuleImportStrc*)’:
../Engine/Platform_Linux.cpp:217:19: error: ‘FS’ has not been declared
  217 |    bModuleFound = FS::Find("libD2Client.so", szModulePath, MAX_D2PATH_ABSOLUTE);
      |                   ^~
../Engine/Platform_Linux.cpp:221:19: error: ‘FS’ has not been declared
  221 |    bModuleFound = FS::Find("libD2Server.so", szModulePath, MAX_D2PATH_ABSOLUTE);
      |                   ^~
../Engine/Platform_Linux.cpp:223:3: error: ‘Log_ErrorAssertReturn’ was not declared in this scope
  223 |   Log_ErrorAssertReturn(bModuleFound, nullptr);
      |   ^~~~~~~~~~~~~~~~~~~~~
samu: subcommand failed
```
3.
```
[63/71] Building CXX object CMakeFiles/game.dir/Engine/FileSystem.cpp.o
samu: job failed: g++  -DD2EXE -I/usr/include/SDL2 -std=gnu++11 -MD -MT CMakeFiles/game.dir/Engine/FileSystem.cpp.o -MF CMakeFiles/game.dir/Engine/FileSystem.cpp.o.d -o CMakeFiles/game.dir/Engine/FileSystem.cpp.o -c ../Engine/FileSystem.cpp
../Engine/FileSystem.cpp:100:41: warning: multi-character character constant [-Wmultichar]
  100 |   else if (path[0] == '.' && path[1] == '..')
      |                                         ^~~~
../Engine/FileSystem.cpp:521:48: error: macro "Log_WarnAssertReturn" requires 2 arguments, but only 1 given
  521 |   Log_WarnAssertReturn(!pRecord->bLoadedFromMPQ);
      |                                                ^
In file included from ../Engine/FileSystem.cpp:2:
../Engine/Logging.hpp:8: note: macro "Log_WarnAssertReturn" defined here
    8 | #define Log_WarnAssertReturn(x, y) if(!(x)) { Log::Warning(__FILE__, __LINE__, "" #x); return y; }
      | 
In file included from ../Engine/FileSystem.hpp:2,
                 from ../Engine/FileSystem.cpp:1:
../Engine/../Shared/D2Shared.hpp:738:80: warning: ‘visibility’ attribute ignored [-Wattributes]
  738 | typedef D2EXPORT D2ModuleExportStrc* (*GetAPIType)(D2ModuleImportStrc* pImports);
      |                                                                                ^
../Engine/FileSystem.cpp: In function ‘void FS::Seek(fs_handle, size_t, int)’:
../Engine/FileSystem.cpp:521:3: error: ‘Log_WarnAssertReturn’ was not declared in this scope
  521 |   Log_WarnAssertReturn(!pRecord->bLoadedFromMPQ);
      |   ^~~~~~~~~~~~~~~~~~~~
samu: subcommand failed
```